### PR TITLE
Added solution with zero Overlap - Neel Shah

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Also, if you think there are any bugs in the provided code, feel free to fix the
 
 | Rank | Name            | Overlap     | Wirelength (um) | Runtime (s) | Notes                |
 |------|-----------------|-------------|-----------------|-------------|----------------------|
-| 1    | Prithvi Seran   | 0.0499      | 0.4890          | 398.58      |                      |
-| 2    | partcl example  | 0.8         | 0.4             | 5           | example              |
-| 3    | Add Yours!      |             |                 |             |                      |
+| 1    | Neel  Shah   | 0.0000      | 0.5445         | 45.40      |  Zero overlaps on all tests, adaptive schedule + early stop                    |
+| 2    | Prithvi Seran   | 0.0499      | 0.4890          | 398.58      |                      |
+| 3    | partcl example  | 0.8         | 0.4             | 5           | example              |
+| 4    | Add Yours!      |             |                 |             |                      |
 
 > **To add your results:**  
 > Insert a new row in the table above with your name, overlap, wirelength, and any notes. Ensure you sort by overlap.


### PR DESCRIPTION
<html><head></head><body><h1>VLSI Cell Placement — Overlap Loss &amp; Training Strategy</h1>
<h2>Summary</h2>
<p>Implemented a fast, differentiable, <strong>vectorized overlap loss</strong> and tuned training to drive overlaps to zero across sizes. Verified on both demo and test suite: <strong>all 10 tests pass</strong> with <strong>average overlap 0.0000</strong>.</p>
<hr>
<h2>Overlap Loss</h2>
<p><strong>Pairwise axis-aligned overlap via broadcasting</strong></p>
<ul>
<li>
<p>overlap_x = ReLU( (w_i + w_j)/2 + margin − |dx| )</p>
</li>
<li>
<p>overlap_y = ReLU( (h_i + h_j)/2 + margin − |dy| )</p>
</li>
<li>
<p>Area penalty = (overlap_x * overlap_y)^2, normalized by total area</p>
</li>
<li>
<p>A positive <strong>margin</strong> pushes cells slightly beyond touch to avoid micro-overlaps in discrete checks.</p>
</li>
</ul>
<hr>
<h2>Training Strategy</h2>
<p><strong>Adaptive schedule by problem size + early stop when overlaps vanish</strong></p>
<p><strong>Overlap weight scheduling</strong></p>
<ul>
<li>
<p>First third of epochs: <strong>5×</strong> base overlap weight</p>
</li>
<li>
<p>Second third: <strong>2×</strong> base</p>
</li>
<li>
<p>Final third: <strong>1×</strong> base</p>
</li>
</ul>
<p><strong>Optimization details</strong></p>
<ul>
<li>
<p>Learning-rate decay: <strong>×0.5</strong> at 50% and 75% of training</p>
</li>
<li>
<p>Higher gradient clip to avoid stalling</p>
</li>
<li>
<p>Early stop with a vectorized exact-overlap check</p>
</li>
</ul>
<hr>
<h2>Default Parameters</h2>

Parameter | Value | Notes
-- | -- | --
overlap margin | 1.0 | Helps prevent micro-overlaps
learning rate | 0.1 | ≥1500 cells: 0.2; 300–1499: 0.15
lambda (wirelength) | 1.0 | Balances wirelength vs. overlap
lambda (overlap) | 1000.0 | ≥1500 cells: ≥5000; 300–1499: ≥2000
epochs | 1000 | ≥1500: ≤800; 300–1499: ≤900
grad clip | 100.0 | Stabilizes training
early stop | enabled | Stops once overlaps hit zero
LR decay | ×0.5 at 50% & 75% | Improves convergence


<hr>
<h2>Test Suite Results (10 cases)</h2>
<ul>
<li>
<p><strong>Average Overlap:</strong> <strong>0.0000</strong></p>
</li>
<li>
<p><strong>Average Wirelength (normalized):</strong> <strong>0.5445</strong></p>
</li>
<li>
<p><strong>Total Runtime:</strong> <strong>55.13s</strong></p>
</li>
<li>
<p><strong>Largest case (2010 cells):</strong> <strong>PASS</strong>, 0 overlap, <strong>50.03s</strong></p>
</li>
</ul>
<hr>
<h2>Comparison to README Baseline</h2>
<ul>
<li>
<p><strong>Overlap:</strong> <strong>0.0 vs 0.8</strong> (improved)</p>
</li>
<li>
<p><strong>Wirelength:</strong> ~<strong>0.54</strong> normalized (baseline example <strong>0.4</strong> is lower; this solution prioritizes robust zero-overlap convergence)</p>
</li>
<li>
<p><strong>Runtime:</strong> consistent; largest case ≈<strong>50s</strong></p>
</li>
</ul>
<hr>
<h2>Notes &amp; Future Refinements</h2>
<ul>
<li>
<p>To trade slightly better wirelength while <strong>keeping zero overlaps</strong>, reduce <strong>margin</strong> to <strong>0.2–0.5</strong> and/or add a short <strong>refinement phase</strong> after overlaps are gone (smaller overlap weight, same early-stop).</p>
</li>
<li>
<p>For <strong>extremely large designs</strong>, consider increasing the first-phase weight or checking early-stop more frequently to reduce wasted epochs.</p>
</li>
</ul></body></html>